### PR TITLE
Lint markdown and add icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
-Timeliner
-=========
-A [Posh] (https://github.com/vvvv/Posh) based timeline that can be controlled by and sends out its values via [OSC] (http://opensoundcontrol.org). 
+# Timeliner
 
-Brought to you by [vvvv] (http://vvvv.org).
+A [Posh](https://github.com/vvvv/Posh) based timeline that can be controlled by and sends out its values via [OSC](http://opensoundcontrol.org). 
+
+Brought to you by [vvvv](http://vvvv.org).
 
 Requires Internet Explorer >= 10 to be installed on your system. 
 
-Looking for a binary download? Get it [here] (http://vvvv.org/contribution/timelinersa-nextgeneration).
+Looking for a binary download? Get it [here](http://vvvv.org/contribution/timelinersa-nextgeneration).
 
 ### Track Types
 * Value
 * String
 
 ### Mouse Interaction
+
 * add a track via rightclick in the empty area
 * add a keyframe in a track via doubleclick
 * show track menu via rightclick on a track
 * show keyframe menu via rightclick on a keyframe
 * show ruler menu via rightclick in the ruler area
-* add keyframes to selection by pressing Ctrl while selecting
-* remove keyframes from selection by pressing Alt while selecting
-* in menues:
- * change numbers using the mouse wheel (also use Shift/Ctrl/Alt vvvv-style to change stepsize)
+* add keyframes to selection by pressing <kbd>Ctrl</kbd> while selecting
+* remove keyframes from selection by pressing <kbd>Alt</kbd> while selecting
+* in menus:
+ * change numbers using the mouse wheel (also use <kbd>Shift</kbd>/<kbd>Ctrl</kbd>/<kbd>Alt</kbd> vvvv-style to change stepsize)
  * change numbers and text via rightclick
 * pan (scroll in time) via right-drag left/right
 * zoom via right-drag up/down
@@ -29,28 +30,31 @@ Looking for a binary download? Get it [here] (http://vvvv.org/contribution/timel
 * right-drag the timebar to have it snap to keyframes
 
 ### Keyboard Interaction
+
 Function| Shortcut
 ------------- | -------------
 Toggle Play | SPACE
-Stop | BackSpace
-Undo | Ctrl + Z
-Redo | Ctrl + Shift + Z
-Set in point | I
-Set out point | O
-Select all keyframes in active track | Ctrl + A
-Select all keyframes | Ctrl + Shift + A
-Delete selected keyframes | Del
-Toggle Collapse active track | Ctrl+<
+Stop | <kbd>Backspace</kbd>
+Undo | <kbd>Ctrl + Z</kbd>
+Redo | <kbd>Ctrl + Shift + Z</kbd>
+Set in point | <kbd>I</kbd>
+Set out point | <kbd>O</kbd>
+Select all keyframes in active track | <kbd>Ctrl + A</kbd>
+Select all keyframes | <kbd>Ctrl + Shift + A</kbd>
+Delete selected keyframes | <kbd>Del</kbd>
+Toggle Collapse active track | <kbd>Ctrl+</kbd>
 Nudge selected keyframes by one frame | Left/Right Arrow Keys
 Nudge selected keyframes values | Up/Down Arrow Keys (also use Shift/Ctrl/Alt vvvv-style to change stepsize)
 Jump to next/previous keyframe | Up/Down Arrow Keys (with no keyframe selected)
-Change EASE mode of selected keyframe | E (toggles through: In, Out, InOut, None)
-Reload page in case it is frozen or to reload CSS | F5
+Change EASE mode of selected keyframe | <kbd>E</kbd> (toggles through: In, Out, InOut, None)
+Reload page in case it is frozen or to reload CSS | <kbd>F5</kbd>
 
 ### Styling
-Edit web\project.css if you want to change colors, stroke-widths or fonts.
+
+Edit `web\project.css` if you want to change colors, stroke-widths or fonts.
 
 ### Receiving OSC
+
 All of Timeliners current values are being sent via UDP using the OSC protocoll. Specify a target IP address (default: 127.0.0.1 ie. localhost) and a port (default: 4444) via Main Menu -> OSC.
 
 All values are sent in one OSC-Bundle. The individual messages addresses comprise of the specified "Prefix" + the pinname. e.g.:
@@ -61,6 +65,7 @@ In addition the current time is sent via:
 * /timeliner/time
 
 ### Sending OSC
+
 TimelinerSA can be remote controlled via OSC commands. It listenes to commands sent to the port set via the "Receive Port" numberbox in the interface (which defaults to 5555).
 
 Send the commands to the "Prefix" + the command you like to controll. e.g.:
@@ -88,12 +93,13 @@ Navigate to http://127.0.0.1:4444 with your browser to see a list of available t
 If you want to access a timeline other than via localhost make sure to run TimelinerSA.exe as admin.
 
 ### Building Timeliner from Source
-The Timeliner.sln requires [Posh] (https://github.com/vvvv/Posh) to be cloned right next to the Timeliner\ directory. That should be it.
+
+The Timeliner.sln requires [Posh](https://github.com/vvvv/Posh) to be cloned right next to the Timeliner\ directory. That should be it.
 
 ### Similar Projects:
-* [TimelinerSA] (http://vvvv.org/documentation/timelinersa)
-* [Duration] (http://www.duration.cc/)
-* [Vezér] (http://www.vezerapp.hu/)
-* [Bigfug Timeline] (http://www.bigfug.com/software/timeline/)
-* [IanniX] (http://www.iannix.org/)
-* [KluppeTimeLine] (http://core.servus.at/node/1424)
+* [TimelinerSA](http://vvvv.org/documentation/timelinersa)
+* [Duration](http://www.duration.cc/)
+* [Vezér](http://www.vezerapp.hu/)
+* [Bigfug Timeline](http://www.bigfug.com/software/timeline/)
+* [IanniX](http://www.iannix.org/)
+* [KluppeTimeLine](http://core.servus.at/node/1424)


### PR DESCRIPTION
I linted the README to work under the new rules under the GFM parser, which can be read about here: https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown .

This PR fixes:

* Headers
* Links
* Key icons